### PR TITLE
Update _databases.py

### DIFF
--- a/awswrangler/_databases.py
+++ b/awswrangler/_databases.py
@@ -60,11 +60,19 @@ def _get_connection_attributes_from_catalog(
                     f"No CA certificate found at {ssl_cert_path}."
                 )
         ssl_context = ssl.create_default_context(cadata=ssl_cadata)
-
+    print("CONNECTION DETAILS", details)
+    if details.has_key("USERNAME"):
+        user = details["USERNAME"]
+    else:
+        user = details["username"]
+    if details.has_key("PASSWORD"):
+        user = details["PASSWORD"]
+    else:
+        user = details["password"]
     return ConnectionAttributes(
         kind=details["JDBC_CONNECTION_URL"].split(":")[1].lower(),
-        user=details["USERNAME"],
-        password=details["PASSWORD"],
+        user=user,
+        password=password,
         host=details["JDBC_CONNECTION_URL"].split(":")[-2].replace("/", "").replace("@", ""),
         port=int(port),
         database=dbname if dbname is not None else database,


### PR DESCRIPTION
Added a case check for the password and username fields for the glue connection connector when retrieving from catalog.

### Feature or Bugfix
- Bugfix

### Detail
Context: When using an aws secret created and managed by RDS as the credential for a glue postgresql connector, 
Problem: The awswrangler library throws an error looking for "USERNAME" and "PASSWORD" keys in the connection details dict when the actual key set by RDS is "username" and "password" that is stored in the secret.

### Relates
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
